### PR TITLE
Update footnotes in the sidebar

### DIFF
--- a/assets/ts/footnotes.ts
+++ b/assets/ts/footnotes.ts
@@ -114,6 +114,40 @@ function populateFootnotesWidget() {
         li.innerHTML = decodeHTMLEntities(content);
         widgetList.appendChild(li);
     });
+    
+    // Set up alignment after populating
+    alignFootnotesWidget();
+}
+
+function alignFootnotesWidget() {
+    const widgetList = document.querySelector('.widget--footnotes .footnotes-list');
+    if (!widgetList) return;
+    
+    const footnotes = document.querySelectorAll('.inline-footnote');
+    const footnoteItems = widgetList.querySelectorAll('.footnote-item');
+    
+    footnotes.forEach((footnote, index) => {
+        const sup = footnote.querySelector('.footnote-number') as HTMLElement;
+        const footnoteItem = footnoteItems[index] as HTMLElement;
+        
+        if (!sup || !footnoteItem) return;
+        
+        // Calculate the Y-coordinate relative to the viewport
+        const supRect = sup.getBoundingClientRect();
+        const widgetRect = widgetList.getBoundingClientRect();
+        
+        // Calculate the relative position within the sidebar widget
+        const relativeY = supRect.top - widgetRect.top;
+        
+        // Apply the relative position to the footnote item
+        footnoteItem.style.position = 'absolute';
+        footnoteItem.style.top = `${relativeY}px`;
+        footnoteItem.style.transform = 'translateY(-50%)'; // Center vertically on the target position
+    });
+}
+
+function updateFootnotesAlignment() {
+    alignFootnotesWidget();
 }
 
 // Call both setupFootnotes and populateFootnotesWidget on DOMContentLoaded
@@ -121,8 +155,16 @@ if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
         setupFootnotes();
         populateFootnotesWidget();
+        
+        // Add scroll event listener to maintain alignment
+        window.addEventListener('scroll', updateFootnotesAlignment);
+        window.addEventListener('resize', updateFootnotesAlignment);
     });
 } else {
     setupFootnotes();
     populateFootnotesWidget();
+    
+    // Add scroll event listener to maintain alignment
+    window.addEventListener('scroll', updateFootnotesAlignment);
+    window.addEventListener('resize', updateFootnotesAlignment);
 } 

--- a/assets/ts/footnotes.ts
+++ b/assets/ts/footnotes.ts
@@ -139,10 +139,9 @@ function alignFootnotesWidget() {
         const supRect = sup.getBoundingClientRect();
         const widgetRect = widgetList.getBoundingClientRect();
         
-        // Calculate the relative position within the sidebar widget
-        const relativeY = supRect.top - widgetRect.top;
-        
-        // Get the height of the footnote item
+        // Align the top of the sidebar footnote box with the top of the <sup> number, plus a small offset
+        const offset = 60;
+        const relativeY = supRect.top - widgetRect.top + offset;
         const itemHeight = footnoteItem.offsetHeight || 50; // fallback height
         
         positions.push({
@@ -173,7 +172,6 @@ function alignFootnotesWidget() {
     positions.forEach(({ top, element }) => {
         element.style.position = 'absolute';
         element.style.top = `${top}px`;
-        element.style.transform = 'translateY(-50%)'; // Center vertically on the target position
     });
 }
 

--- a/assets/ts/footnotes.ts
+++ b/assets/ts/footnotes.ts
@@ -126,6 +126,9 @@ function alignFootnotesWidget() {
     const footnotes = document.querySelectorAll('.inline-footnote');
     const footnoteItems = widgetList.querySelectorAll('.footnote-item');
     
+    // First pass: calculate initial positions
+    const positions: { top: number; height: number; element: HTMLElement }[] = [];
+    
     footnotes.forEach((footnote, index) => {
         const sup = footnote.querySelector('.footnote-number') as HTMLElement;
         const footnoteItem = footnoteItems[index] as HTMLElement;
@@ -139,10 +142,38 @@ function alignFootnotesWidget() {
         // Calculate the relative position within the sidebar widget
         const relativeY = supRect.top - widgetRect.top;
         
-        // Apply the relative position to the footnote item
-        footnoteItem.style.position = 'absolute';
-        footnoteItem.style.top = `${relativeY}px`;
-        footnoteItem.style.transform = 'translateY(-50%)'; // Center vertically on the target position
+        // Get the height of the footnote item
+        const itemHeight = footnoteItem.offsetHeight || 50; // fallback height
+        
+        positions.push({
+            top: relativeY,
+            height: itemHeight,
+            element: footnoteItem
+        });
+    });
+    
+    // Second pass: resolve overlaps
+    const minSpacing = 10; // minimum spacing between items in pixels
+    
+    for (let i = 1; i < positions.length; i++) {
+        const current = positions[i];
+        const previous = positions[i - 1];
+        
+        // Check if current item overlaps with previous item
+        const currentTop = current.top;
+        const previousBottom = previous.top + previous.height;
+        
+        if (currentTop < previousBottom + minSpacing) {
+            // Adjust current item position to avoid overlap
+            current.top = previousBottom + minSpacing;
+        }
+    }
+    
+    // Third pass: apply final positions
+    positions.forEach(({ top, element }) => {
+        element.style.position = 'absolute';
+        element.style.top = `${top}px`;
+        element.style.transform = 'translateY(-50%)'; // Center vertically on the target position
     });
 }
 

--- a/exampleSite/content/post/rich-content/index.md
+++ b/exampleSite/content/post/rich-content/index.md
@@ -9,7 +9,7 @@ tags = [
 ]
 +++
 
-Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
+Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes{{< footnote id="1" >}}A quick example of a footnote. See the section below for how this works.{{< /footnote >}} that enable static and no-JS versions of various social media embeds.
 <!--more-->
 ---
 
@@ -71,8 +71,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 Stack adds an `footnote` shortcode for inline footnotes that display as popups. For example:
 
-This is a sentence with an inline footnote{{< footnote id="1" >}}This is the footnote content that will appear in a popup when you click on the footnote number. You can include **markdown formatting** and [links](https://example.com) in the footnote content.{{< /footnote >}} that demonstrates the functionality.
+This is a sentence with an inline footnote{{< footnote id="2" >}}This is the footnote content that will appear in a popup when you click on the footnote number. You can include **markdown formatting** and [links](https://example.com) in the footnote content.{{< /footnote >}} that demonstrates the functionality.
 
-You can also have multiple footnotes in the same paragraph{{< footnote id="2" >}}This is another footnote with different content. Footnotes are automatically numbered and can contain any markdown content.{{< /footnote >}} to show how they work together.
+You can also have multiple footnotes in the same paragraph{{< footnote id="3" >}}This is another footnote with different content. Footnotes are automatically numbered and can contain any markdown content.{{< /footnote >}} to show how they work together.
 
 The footnotes appear as small numbered circles that you can click to reveal the content in a popup. The popup can be closed by clicking the × button, clicking outside the popup, or pressing the Escape key.

--- a/layouts/partials/widget/toc.html
+++ b/layouts/partials/widget/toc.html
@@ -1,8 +1,4 @@
 <section class="widget footnotes">
-    <div class="widget-icon">
-        {{ partial "helper/icon" "messages" }}
-    </div>
-    <h2 class="widget-title section-title">Footnotes</h2>
     <div class="widget--footnotes">
         <ol class="footnotes-list"></ol>
     </div>


### PR DESCRIPTION
When the screen is wide enough, footnotes are displayed in the sidebar.

Changes:
- sidebar footnotes track the location of the footnote in the main content
- cleans up the theming of the sidebar footnotes: no title anymore, no icon, and smaller gap between footnote and content

<img width="1470" height="739" alt="Screenshot 2025-07-12 at 7 37 52 PM" src="https://github.com/user-attachments/assets/877b37f9-0a79-4a22-955d-4984b0b97270" />
